### PR TITLE
Remove language argument from debuglink.load_device

### DIFF
--- a/tests/vendor/trezor/utils.py
+++ b/tests/vendor/trezor/utils.py
@@ -43,7 +43,6 @@ def load_client():
         pin=None,
         passphrase_protection=False,
         label="test",
-        language="en-US",
     )
     client.clear_session()
 


### PR DESCRIPTION
Fixing the removal of `language` parameter in https://github.com/trezor/trezor-firmware/pull/3206